### PR TITLE
feat: soporte HEIC en uploads (iPhone)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,18 @@ const nextConfig: NextConfig = {
   // Configuración para Docker (standalone output)
   output: 'standalone',
 
+  // Garantiza que el decodificador HEIC (heic-convert/libheif-js) se incluya
+  // en el output standalone usado por la imagen Docker.
+  outputFileTracingIncludes: {
+    '/api/upload': [
+      './node_modules/heic-convert/**',
+      './node_modules/heic-decode/**',
+      './node_modules/libheif-js/**',
+      './node_modules/jpeg-js/**',
+      './node_modules/pngjs/**',
+    ],
+  },
+
   images: {
     // Formatos de imagen optimizados (AVIF primero, WebP como fallback)
     formats: ['image/avif', 'image/webp'],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/pg": "^8.15.5",
     "archiver": "^7.0.1",
     "framer-motion": "^12.34.1",
+    "heic-convert": "^2.1.0",
     "next": "15.5.3",
     "pg": "^8.16.3",
     "react": "19.1.0",
@@ -34,6 +35,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/heic-convert": "^2.1.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       framer-motion:
         specifier: ^12.34.1
         version: 12.34.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      heic-convert:
+        specifier: ^2.1.0
+        version: 2.1.0
       next:
         specifier: 15.5.3
         version: 15.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -45,6 +48,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.13
+      '@types/heic-convert':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@types/node':
         specifier: ^20
         version: 20.19.17
@@ -816,6 +822,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/heic-convert@2.1.1':
+    resolution: {integrity: sha512-+s14762Nf62z9zziIs7ItvAkSUCS3ls4Z5XPT9BlVve3Q3S4DAnf6qekffMTvEWycSUF+kulkGaSN65fK6eKvg==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -1707,6 +1716,14 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  heic-convert@2.1.0:
+    resolution: {integrity: sha512-1qDuRvEHifTVAj3pFIgkqGgJIr0M3X7cxEPjEp0oG4mo8GFjq99DpCo8Eg3kg17Cy0MTjxpFdoBHOatj7ZVKtg==}
+    engines: {node: '>=12.0.0'}
+
+  heic-decode@2.1.0:
+    resolution: {integrity: sha512-0fB3O3WMk38+PScbHLVp66jcNhsZ/ErtQ6u2lMYu/YxXgbBtl+oKOhGQHa4RpvE68k8IzbWkABzHnyAIjR758A==}
+    engines: {node: '>=8.0.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -1864,6 +1881,9 @@ packages:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1905,6 +1925,10 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libheif-js@1.19.8:
+    resolution: {integrity: sha512-vQJWusIxO7wavpON1dusciL8Go9jsIQ+EUrckauFYAiSTjcmLAsuJh3SszLpvkwPci3JcL41ek2n+LUZGFpPIQ==}
+    engines: {node: '>=8.0.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -2305,6 +2329,10 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  pngjs@6.0.0:
+    resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
+    engines: {node: '>=12.13.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -3397,6 +3425,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/heic-convert@2.1.1': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -4487,6 +4517,16 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  heic-convert@2.1.0:
+    dependencies:
+      heic-decode: 2.1.0
+      jpeg-js: 0.4.4
+      pngjs: 6.0.0
+
+  heic-decode@2.1.0:
+    dependencies:
+      libheif-js: 1.19.8
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -4646,6 +4686,8 @@ snapshots:
 
   jiti@2.5.1: {}
 
+  jpeg-js@0.4.4: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
@@ -4687,6 +4729,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libheif-js@1.19.8: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -5024,6 +5068,8 @@ snapshots:
       confbox: 0.2.2
       exsolve: 1.0.7
       pathe: 2.0.3
+
+  pngjs@6.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { mkdir, writeFile, readdir } from 'fs/promises';
 import path from 'path';
 import { prisma } from '@/lib/prisma';
-import { generateThumbnailForUpload } from '@/lib/thumbnail';
+import { generateThumbnailFromBuffer } from '@/lib/thumbnail';
 import sharp from 'sharp';
+import convert from 'heic-convert';
 import {
   slugify,
   uniqueSlug,
@@ -38,6 +39,15 @@ const ALLOWED_MIME_TYPES = new Set([
   'image/heif',
   'image/tiff',
 ]);
+
+// HEIC/HEIF (formato por defecto del iPhone) no lo decodifica sharp.
+// Se detecta por mime o extensión para convertirlo antes de generar derivados.
+function isHeic(file: File): boolean {
+  const t = (file.type || '').toLowerCase();
+  if (t === 'image/heic' || t === 'image/heif') return true;
+  const ext = path.extname(file.name).toLowerCase();
+  return ext === '.heic' || ext === '.heif';
+}
 
 // POST /api/upload - Subir imágenes
 export async function POST(request: NextRequest) {
@@ -161,12 +171,25 @@ export async function POST(request: NextRequest) {
       // GUARDAR ORIGINAL BYTE-A-BYTE (sin re-encode → calidad y metadatos intactos)
       await writeFile(filePath, buffer);
 
-      // Miniatura WebP aparte (rotate hornea la orientación EXIF en el derivado)
-      // generateThumbnailForUpload escribe destName con extensión .webp en thumbsDir
+      // Buffer procesable por sharp para los DERIVADOS (miniatura/dimensiones/blur).
+      // HEIC (iPhone) no lo decodifica sharp → se convierte a JPEG en memoria.
+      // El original guardado en disco sigue siendo el .heic intacto.
+      let processBuffer = buffer;
+      if (isHeic(file)) {
+        try {
+          processBuffer = Buffer.from(
+            await convert({ buffer, format: 'JPEG', quality: 0.92 })
+          );
+        } catch (e) {
+          console.warn(`No se pudo convertir HEIC ${destName}:`, e);
+        }
+      }
+
+      // Miniatura WebP generada desde el buffer procesable (rotate hornea EXIF)
       const thumbFilename = destName.replace(/\.[^.]+$/, '.webp');
       let thumbUrlValue = thumbUrl(year, folderName, thumbFilename);
       try {
-        await generateThumbnailForUpload(destName, uploadsDir, thumbsDir);
+        await generateThumbnailFromBuffer(processBuffer, path.join(thumbsDir, thumbFilename));
       } catch {
         console.warn(`No se pudo generar thumbnail para ${destName}`);
         thumbUrlValue = uploadUrl(year, folderName, destName); // fallback: usa el original
@@ -177,14 +200,14 @@ export async function POST(request: NextRequest) {
       let realHeight = 600;
       let blurDataUrl: string | null = null;
       try {
-        const meta = await sharp(buffer).rotate().metadata();
+        const meta = await sharp(processBuffer).rotate().metadata();
         realWidth = meta.width || 800;
         realHeight = meta.height || 600;
       } catch {
-        /* HEIC no decodificable u otro: usar defaults */
+        /* formato no decodificable: usar defaults */
       }
       try {
-        const blurBuffer = await sharp(buffer)
+        const blurBuffer = await sharp(processBuffer)
           .rotate()
           .resize(20, 20, { fit: 'inside' })
           .jpeg({ quality: 40 })

--- a/src/lib/thumbnail.ts
+++ b/src/lib/thumbnail.ts
@@ -49,6 +49,31 @@ export async function generateThumbnail(
 }
 
 /**
+ * Genera un thumbnail WebP desde un buffer en memoria.
+ * Útil cuando el original no es legible por sharp (ej. HEIC ya convertido a JPEG).
+ * @param buffer Buffer de una imagen que sharp pueda decodificar (jpeg/png/webp/…)
+ * @param outputPath Ruta completa donde se guardará el thumbnail .webp
+ */
+export async function generateThumbnailFromBuffer(
+  buffer: Buffer,
+  outputPath: string
+): Promise<void> {
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+
+  await sharp(buffer)
+    .rotate()
+    .resize(THUMBNAIL_CONFIG.width, null, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .webp({ quality: THUMBNAIL_CONFIG.quality })
+    .toFile(outputPath);
+}
+
+/**
  * Genera un thumbnail para un archivo subido
  * @param filename Nombre del archivo (ej: "1234_abcd.jpg")
  * @param uploadsDir Directorio de uploads


### PR DESCRIPTION
## Resumen

Habilita las fotos **HEIC/HEIF** (formato por defecto del iPhone), que `sharp` no puede decodificar (su libvips excluye el códec HEVC por licencias).

- Al subir un HEIC, se convierte a JPEG **en memoria** con `heic-convert` y desde ahí se generan la miniatura WebP, las dimensiones y el blur.
- El **original `.heic` se guarda byte-a-byte** (calidad intacta) — solo los derivados usan el JPEG convertido.
- Detección por mime (`image/heic`/`image/heif`) y por extensión (`.heic`/`.heif`).
- `next.config.ts`: `outputFileTracingIncludes` para que `heic-convert` y su árbol (`heic-decode`, `libheif-js`, `jpeg-js`, `pngjs`) viajen en el output **standalone** de la imagen Docker.

`heic-convert` usa `libheif-js` en su variante **asm.js (JS puro)** — sin librerías del sistema, portable a cualquier base de Docker.

## Validación

- Conversión HEIC→JPEG→WebP probada en Node y **dentro de la imagen Docker standalone construida** (deps presentes y funcionando).
- E2E por el endpoint real: subir HEIC → original con **sha256 idéntico** al de origen + miniatura `.webp` generada (200) + dimensiones correctas.
- `pnpm test` (15/15), `tsc` (0), `lint` (0 errores), `pnpm build` (exit 0).

## Test Plan
- [ ] Tras desplegar, subir una foto `.heic` real del iPhone y confirmar que aparece su miniatura en la galería.