### PR TITLE
feat: variante display para el visor (velocidad)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-variante-display-visor.md
+++ b/docs/superpowers/plans/2026-06-14-variante-display-visor.md
@@ -1,0 +1,444 @@
+# Variante "display" para el visor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generar una versión WebP de máx 2048px ("display") de cada foto y usarla en el visor (en vez del original de varios MB), conservando el original intacto, para que abrir/deslizar fotos sea rápido.
+
+**Architecture:** La display es un tercer derivado, hermano de la miniatura, guardado en el árbol de thumbnails como `<base>.display.webp` y servido por la ruta `/thumbnails/[...path]` existente (sin volumen ni ruta nuevos). Se genera en el upload (desde el mismo buffer procesable, sirve para HEIC) y se rellena para las fotos existentes con un script. El visor usa `Image.displayUrl` con fallback al original.
+
+**Tech Stack:** Next.js 15, Prisma 6 + PostgreSQL, Sharp, heic-convert, Vitest, pnpm.
+
+---
+
+## Estructura de archivos
+
+| Archivo | Responsabilidad |
+|---|---|
+| `src/lib/storage.ts` (mod) | `displayName(name)` → `<base>.display.webp` + test |
+| `src/lib/thumbnail.ts` (mod) | `generateDisplayFromBuffer(buffer, outputPath)` |
+| `prisma/schema.prisma` (mod) + migración manual | `Image.displayUrl` |
+| `src/app/api/upload/route.ts` (mod) | generar display + guardar `displayUrl` |
+| `src/app/api/albums/[id]/images/route.ts` (mod) | incluir `displayUrl` en la respuesta |
+| `src/app/api/images/[id]/route.ts` (mod) | incluir `displayUrl` (GET) + borrar `.display.webp` (DELETE) |
+| `src/types/index.ts` (mod) | `displayUrl` en `AlbumImage` |
+| `src/components/ImageGallery.tsx` (mod) | usar `displayUrl` en imagen principal + preload; `displayUrl` en `ImageData` |
+| `scripts/generate-display-variants.ts` (nuevo) | backfill de fotos existentes |
+
+**Entorno:** Hay (o el controlador levanta) un Postgres de dev en el puerto **5433**: `DATABASE_URL="postgresql://postgres:password@localhost:5433/album_fotos?schema=public"`. El schema de dev se sincroniza con `prisma db push` (NO `migrate dev`, por el bug de orden de migraciones en BD fresca).
+
+---
+
+## Task 1: `displayName` + `generateDisplayFromBuffer`
+
+**Files:**
+- Modify: `src/lib/storage.ts`
+- Test: `src/lib/storage.test.ts`
+- Modify: `src/lib/thumbnail.ts`
+
+- [ ] **Step 1: Test que falla para `displayName`**
+
+Añadir a `src/lib/storage.test.ts`:
+
+```ts
+import { displayName } from './storage';
+
+describe('displayName', () => {
+  test('reemplaza la extensión por .display.webp', () => {
+    expect(displayName('IMG_1234.jpg')).toBe('IMG_1234.display.webp');
+    expect(displayName('foto.HEIC')).toBe('foto.display.webp');
+  });
+  test('sin extensión, agrega .display.webp', () => {
+    expect(displayName('archivo')).toBe('archivo.display.webp');
+  });
+});
+```
+
+- [ ] **Step 2: Correr y verificar que falla**
+
+Run: `pnpm test`
+Expected: FAIL (displayName no definido)
+
+- [ ] **Step 3: Implementar `displayName`**
+
+Añadir a `src/lib/storage.ts` (ya importa `path`):
+
+```ts
+/** Nombre del archivo "display" derivado del nombre destino: IMG_1.jpg → IMG_1.display.webp */
+export function displayName(name: string): string {
+  const ext = path.extname(name);
+  return name.slice(0, name.length - ext.length) + '.display.webp';
+}
+```
+
+- [ ] **Step 4: Implementar `generateDisplayFromBuffer`**
+
+Añadir a `src/lib/thumbnail.ts` (junto a `generateThumbnailFromBuffer`):
+
+```ts
+const DISPLAY_CONFIG = {
+  maxSize: 2048,
+  quality: 82,
+};
+
+/** Genera la versión "display" (máx 2048px WebP) para el visor, desde un buffer. */
+export async function generateDisplayFromBuffer(
+  buffer: Buffer,
+  outputPath: string
+): Promise<void> {
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  await sharp(buffer)
+    .rotate()
+    .resize(DISPLAY_CONFIG.maxSize, DISPLAY_CONFIG.maxSize, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .webp({ quality: DISPLAY_CONFIG.quality })
+    .toFile(outputPath);
+}
+```
+
+- [ ] **Step 5: Correr tests y tsc**
+
+Run: `pnpm test && npx tsc --noEmit`
+Expected: PASS, exit 0
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/storage.ts src/lib/storage.test.ts src/lib/thumbnail.ts
+git commit -m "feat: displayName y generateDisplayFromBuffer (variante 2048px)"
+```
+
+---
+
+## Task 2: Schema `Image.displayUrl` + migración
+
+**Files:**
+- Modify: `prisma/schema.prisma` (modelo `Image`)
+- Create: `prisma/migrations/20260614000000_add_image_display_url/migration.sql`
+
+- [ ] **Step 1: Añadir el campo al schema**
+
+En `prisma/schema.prisma`, en el modelo `Image`, tras `thumbnailUrl`:
+
+```prisma
+  displayUrl      String?
+```
+
+- [ ] **Step 2: Crear la migración manualmente** (no usar `migrate dev`)
+
+Create `prisma/migrations/20260614000000_add_image_display_url/migration.sql`:
+
+```sql
+-- AlterTable
+ALTER TABLE "public"."images" ADD COLUMN     "displayUrl" TEXT;
+```
+
+- [ ] **Step 3: Regenerar el cliente Prisma**
+
+Run: `npx prisma generate`
+Expected: "Generated Prisma Client"
+
+- [ ] **Step 4: Aplicar a la BD de dev y verificar tipos**
+
+Run:
+```bash
+DATABASE_URL="postgresql://postgres:password@localhost:5433/album_fotos?schema=public" pnpm exec prisma db push --skip-generate
+npx tsc --noEmit
+```
+Expected: db push aplica el cambio; tsc exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat: campo Image.displayUrl + migración"
+```
+
+---
+
+## Task 3: Upload genera la display y guarda `displayUrl`
+
+**Files:**
+- Modify: `src/app/api/upload/route.ts`
+
+- [ ] **Step 1: Imports**
+
+En `src/app/api/upload/route.ts`, añadir `displayName` al import de `@/lib/storage` y `generateDisplayFromBuffer` al import de `@/lib/thumbnail`:
+
+```ts
+import { generateThumbnailFromBuffer, generateDisplayFromBuffer } from '@/lib/thumbnail';
+// y en el import de @/lib/storage, añadir displayName a la lista existente
+```
+
+- [ ] **Step 2: Generar la display tras la miniatura**
+
+En el loop, justo después del bloque que genera la miniatura (`generateThumbnailFromBuffer(...)`) y antes del bloque de dimensiones, añadir:
+
+```ts
+      // Versión "display" (2048px WebP) para el visor
+      let displayUrlValue: string | null = thumbUrl(year, folderName, displayName(destName));
+      try {
+        await generateDisplayFromBuffer(processBuffer, path.join(thumbsDir, displayName(destName)));
+      } catch {
+        console.warn(`No se pudo generar display para ${destName}`);
+        displayUrlValue = null;
+      }
+```
+
+- [ ] **Step 3: Guardar `displayUrl` en la fila**
+
+En el `data` de `prisma.image.create`, añadir tras `thumbnailUrl`:
+
+```ts
+          displayUrl: displayUrlValue,
+```
+
+- [ ] **Step 4: Verificar tsc y lint**
+
+Run: `npx tsc --noEmit && pnpm lint`
+Expected: exit 0, sin errores nuevos
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/upload/route.ts
+git commit -m "feat: el upload genera la variante display y guarda displayUrl"
+```
+
+---
+
+## Task 4: Exponer `displayUrl` en API y tipos
+
+**Files:**
+- Modify: `src/types/index.ts` (interface `AlbumImage`)
+- Modify: `src/app/api/albums/[id]/images/route.ts`
+- Modify: `src/app/api/images/[id]/route.ts` (GET)
+
+- [ ] **Step 1: Tipo**
+
+En `src/types/index.ts`, en la interface `AlbumImage`, añadir junto a `thumbnailUrl`:
+
+```ts
+  displayUrl?: string | null;
+```
+
+- [ ] **Step 2: Incluir en la respuesta de imágenes del álbum**
+
+En `src/app/api/albums/[id]/images/route.ts`, localizar el `select` (o el mapeo) de imágenes y asegurar que `displayUrl` se incluye. Si usa `select`, añadir `displayUrl: true`; si devuelve el objeto completo (sin select), ya viene. Verificar leyendo el archivo y ajustar para que `displayUrl` llegue al cliente.
+
+- [ ] **Step 3: Incluir en `GET /api/images/[id]`**
+
+En `src/app/api/images/[id]/route.ts` (GET), asegurar que la respuesta incluye `displayUrl` (igual criterio que Step 2).
+
+- [ ] **Step 4: Verificar tsc y lint**
+
+Run: `npx tsc --noEmit && pnpm lint`
+Expected: exit 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/types/index.ts src/app/api/albums/[id]/images/route.ts src/app/api/images/[id]/route.ts
+git commit -m "feat: exponer displayUrl en API y tipos"
+```
+
+---
+
+## Task 5: El visor usa la display
+
+**Files:**
+- Modify: `src/components/ImageGallery.tsx`
+
+- [ ] **Step 1: Tipo `ImageData`**
+
+En `src/components/ImageGallery.tsx`, en la interface `ImageData` (cerca de la línea 9, donde están `fileUrl`/`thumbnailUrl`), añadir:
+
+```ts
+  displayUrl?: string | null;
+```
+
+- [ ] **Step 2: Imagen principal usa la display**
+
+Localizar el `<img src={img.fileUrl}` de la imagen principal del visor (≈ línea 357) y cambiarlo a:
+
+```tsx
+                    src={img.displayUrl || img.fileUrl}
+```
+
+- [ ] **Step 3: Preload de adyacentes usa la display**
+
+Localizar la precarga (≈ línea 243, `p.src = images[i].fileUrl`) y cambiarla a:
+
+```ts
+      .forEach(i => { const p = new window.Image(); p.src = images[i].displayUrl || images[i].fileUrl; });
+```
+
+(Mantener la lógica de descarga/ver original con `fileUrl` si existe — NO cambiarla.)
+
+- [ ] **Step 4: Verificar tsc, lint y build**
+
+Run: `npx tsc --noEmit && pnpm lint && pnpm build`
+Expected: exit 0
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/ImageGallery.tsx
+git commit -m "feat: el visor carga la variante display (preload incluido)"
+```
+
+---
+
+## Task 6: Borrar imagen elimina también la display
+
+**Files:**
+- Modify: `src/app/api/images/[id]/route.ts` (DELETE)
+
+- [ ] **Step 1: Borrar el archivo `.display.webp`**
+
+En el bloque DELETE que borra archivos físicos (tras borrar el thumbnail), añadir el borrado de la display. La display vive junto al thumbnail; su URL es `thumbnailUrl` con sufijo `.display.webp`, pero es más robusto derivarla de `displayUrl` si está guardada. Implementar:
+
+```ts
+    if (image.displayUrl && image.displayUrl.startsWith('/thumbnails/')) {
+      try {
+        await unlink(safeResolve(THUMBS_BASE, image.displayUrl.replace(/^\/thumbnails\//, '')));
+      } catch { console.warn('Display no encontrada:', image.displayUrl); }
+    }
+```
+
+(`safeResolve` y `THUMBS_BASE` ya se importan en este archivo para el borrado de la miniatura; si no, añadirlos al import de `@/lib/storage`.)
+
+- [ ] **Step 2: Verificar tsc y lint**
+
+Run: `npx tsc --noEmit && pnpm lint`
+Expected: exit 0
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/api/images/[id]/route.ts
+git commit -m "fix: borrar imagen elimina también su variante display"
+```
+
+---
+
+## Task 7: Script de backfill
+
+**Files:**
+- Create: `scripts/generate-display-variants.ts`
+- Modify: `package.json` (script)
+
+- [ ] **Step 1: Implementar el script**
+
+Create `scripts/generate-display-variants.ts`:
+
+```ts
+import { PrismaClient } from '@prisma/client';
+import { readFile, access } from 'fs/promises';
+import path from 'path';
+import convert from 'heic-convert';
+import { generateDisplayFromBuffer } from '../src/lib/thumbnail';
+import { displayName, albumThumbDir, thumbUrl, UPLOADS_BASE } from '../src/lib/storage';
+
+const prisma = new PrismaClient();
+const exists = (p: string) => access(p).then(() => true).catch(() => false);
+
+function isHeicName(name: string): boolean {
+  const ext = path.extname(name).toLowerCase();
+  return ext === '.heic' || ext === '.heif';
+}
+
+async function main() {
+  const images = await prisma.image.findMany({ include: { album: true } });
+  let done = 0, skipped = 0, failed = 0;
+
+  for (const img of images) {
+    if (!img.album?.folderName) { skipped++; continue; }
+    const { year, folderName } = { year: img.album.year, folderName: img.album.folderName };
+    const origName = path.basename(img.fileUrl);
+    const dispName = displayName(origName);
+    const outPath = path.join(albumThumbDir(year, folderName), dispName);
+    const wantUrl = thumbUrl(year, folderName, dispName);
+
+    if (img.displayUrl === wantUrl && (await exists(outPath))) { skipped++; continue; }
+
+    const srcPath = path.join(UPLOADS_BASE, year.toString(), folderName, origName);
+    if (!(await exists(srcPath))) { console.warn(`sin original: ${img.fileUrl}`); failed++; continue; }
+
+    try {
+      let buf = await readFile(srcPath);
+      if (isHeicName(origName)) {
+        buf = Buffer.from(await convert({ buffer: buf, format: 'JPEG', quality: 0.92 }));
+      }
+      await generateDisplayFromBuffer(buf, outPath);
+      await prisma.image.update({ where: { id: img.id }, data: { displayUrl: wantUrl } });
+      done++;
+      if (done % 50 === 0) console.log(`${done} displays generadas...`);
+    } catch (e) {
+      console.error(`falló ${img.fileUrl}:`, (e as Error).message);
+      failed++;
+    }
+  }
+  console.log(`Backfill display completo. generadas=${done} saltadas=${skipped} fallidas=${failed}`);
+}
+
+main().then(() => prisma.$disconnect()).catch(async (e) => { console.error(e); await prisma.$disconnect(); process.exit(1); });
+```
+
+- [ ] **Step 2: Añadir script a package.json**
+
+En `"scripts"`:
+
+```json
+"generate-display": "tsx scripts/generate-display-variants.ts",
+```
+
+- [ ] **Step 3: Verificar tsc**
+
+Run: `npx tsc --noEmit`
+Expected: exit 0
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/generate-display-variants.ts package.json
+git commit -m "feat: script de backfill de variantes display"
+```
+
+---
+
+## Task 8: Verificación final (E2E)
+
+**Files:** ninguno (verificación)
+
+- [ ] **Step 1: Suite estática**
+
+Run: `pnpm test && npx tsc --noEmit && pnpm lint && pnpm build`
+Expected: todo en verde.
+
+- [ ] **Step 2: E2E con dev server (lo hace el controlador)**
+
+Con Postgres dev (5433) y `pnpm dev`: crear álbum, subir una foto, y verificar:
+- existe `public/thumbnails/<año>/<slug>/<base>.display.webp`,
+- la fila tiene `displayUrl` poblada,
+- `GET /api/albums/<id>/images` devuelve `displayUrl`,
+- el original sigue intacto (sha256).
+Repetir con un HEIC (debe generar la display vía conversión).
+
+- [ ] **Step 3: Commit (si hubo ajustes)**
+
+```bash
+git add -A && git commit -m "test: verificación de la variante display" || echo "nada que commitear"
+```
+
+---
+
+## Notas de ejecución
+
+- Las tareas que tocan BD/route se verifican con el Postgres de dev en **5433** (`prisma db push`, no `migrate dev`).
+- El backfill en producción se corre tras desplegar, en un contenedor node con los volúmenes montados (mismo patrón que la migración de carpetas), y la columna se agrega en prod con `ALTER TABLE "images" ADD COLUMN IF NOT EXISTS "displayUrl" TEXT;`.
+- Orden recomendado: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8.

--- a/docs/superpowers/specs/2026-06-14-variante-display-visor-design.md
+++ b/docs/superpowers/specs/2026-06-14-variante-display-visor-design.md
@@ -1,0 +1,155 @@
+# Spec: Variante "display" para el visor (velocidad)
+
+**Fecha:** 2026-06-14
+**Estado:** Aprobado (diseño)
+**Alcance:** Generar una versión optimizada de tamaño medio ("display") de cada foto y usarla en el visor (lightbox), en vez del original a tamaño completo, para que abrir y deslizar fotos sea rápido. El original se conserva intacto.
+
+---
+
+## 1. Contexto y problema
+
+El visor (`src/components/ImageGallery.tsx`) carga la **imagen original completa**:
+- Imagen principal: `<img src={img.fileUrl}>` (línea ~357) → el original (JPEG/HEIC de varios MB).
+- Precarga de las dos adyacentes (línea ~243): también el original.
+
+Abrir una foto baja ~4-8 MB y precarga otros ~8-16 MB. En el teléfono con datos esto es lento y el deslizamiento se traba. Es lo opuesto a la "velocidad tipo Google Fotos" que se busca.
+
+### Objetivo
+Que abrir una foto y deslizar entre fotos sea instantáneo, bajando ~400 KB en vez de varios MB, sin perder el acceso al original a calidad total.
+
+### Fuera de alcance (YAGNI)
+- `srcset`/variantes múltiples por foto (una sola variante display alcanza).
+- Cambios de infraestructura (volúmenes/rutas nuevas) — se reutiliza lo existente.
+
+---
+
+## 2. Decisiones tomadas
+
+| Decisión | Elección |
+|---|---|
+| Tamaño de la variante display | **WebP, lado largo máx 2048px**, calidad ~82, sin agrandar (`withoutEnlargement`) |
+| Dónde se guarda | Junto a la miniatura, en el árbol de thumbnails, con sufijo `.display.webp` |
+| Cómo se sirve | Por la ruta catch-all `/thumbnails/[...path]` existente (sin ruta ni volumen nuevo) |
+| Fotos existentes | **Backfill** de las 583 con un script idempotente |
+
+---
+
+## 3. Estructura en disco
+
+Reutiliza el bind mount de thumbnails (sin tocar `docker-compose.yml`):
+
+```
+public/thumbnails/2025/viaje-a-la-playa/
+  IMG_1234.webp           ← miniatura 400px (grilla)        [existente]
+  IMG_1234.display.webp   ← display 2048px (visor)          [NUEVO]
+```
+
+URL de la display: `/thumbnails/2025/viaje-a-la-playa/IMG_1234.display.webp`, servida por el handler de `src/app/thumbnails/[...path]/route.ts` (que ya sirve cualquier archivo bajo `THUMBS_BASE` con sanitización). No requiere cambios en el serving.
+
+---
+
+## 4. Modelo de datos
+
+- Añadir `displayUrl String?` al modelo `Image` (`prisma/schema.prisma`).
+- Migración: en producción se aplica con `ALTER TABLE "images" ADD COLUMN IF NOT EXISTS "displayUrl" TEXT;` (idempotente y seguro, como se hizo con `Album.folderName`, para no chocar con el drift del historial de migraciones). En el repo se versiona la migración Prisma correspondiente (solo el `ADD COLUMN`).
+- El cliente Prisma se regenera con el campo nuevo.
+
+---
+
+## 5. Generación de la variante (lib)
+
+Nueva función en `src/lib/thumbnail.ts`:
+
+```ts
+export async function generateDisplayFromBuffer(buffer: Buffer, outputPath: string): Promise<void>
+```
+- `sharp(buffer).rotate().resize(2048, 2048, { fit: 'inside', withoutEnlargement: true }).webp({ quality: 82 }).toFile(outputPath)`.
+- Crea el directorio de salida si no existe.
+
+Helper de nombre (en `src/lib/storage.ts` o junto a thumbnail): dado el nombre destino del original, la display es `<base>.display.webp`. Centralizar para que upload, backfill y URLs coincidan.
+
+---
+
+## 6. Upload
+
+En `src/app/api/upload/route.ts`, dentro del loop, tras generar la miniatura:
+- Calcular `displayFilename = <base de destName>.display.webp`.
+- `generateDisplayFromBuffer(processBuffer, path.join(thumbsDir, displayFilename))` (usa el mismo `processBuffer` que la miniatura → funciona también para HEIC ya convertido).
+- `displayUrl = thumbUrl(year, folderName, displayFilename)`. Si la generación falla, `displayUrl = null` (el visor cae al original).
+- Guardar `displayUrl` en la fila `Image`.
+
+---
+
+## 7. Backfill de lo existente
+
+Script `scripts/generate-display-variants.ts` (idempotente):
+- Por cada `Image` con `displayUrl` nulo (o cuyo archivo display no exista en disco):
+  - Leer el original desde su ruta (`fileUrl`). Si es HEIC (extensión/mime), convertir a JPEG en memoria con `heic-convert` (igual que el upload).
+  - Generar la display 2048px en `<thumbsDir del álbum>/<base>.display.webp`.
+  - Setear `displayUrl` en la BD.
+- Idempotente: si ya existe el archivo y la URL, saltar.
+- Se corre una vez en el server, en un contenedor node de un solo uso (mismo patrón que la migración de carpetas).
+
+---
+
+## 8. Visor y tipos
+
+`src/components/ImageGallery.tsx`:
+- Imagen principal: `src={image.displayUrl || image.fileUrl}` (línea ~357).
+- Precarga de adyacentes (línea ~243): usar `displayUrl || fileUrl`.
+- La acción de descargar/ver original (si existe) sigue usando `fileUrl`.
+
+Tipos y API:
+- Añadir `displayUrl?: string | null` a `ImageData` (ImageGallery) y a `AlbumImage` (`src/types/index.ts`).
+- Incluir `displayUrl` en los `select`/respuestas que alimentan el visor: `src/app/api/albums/[id]/images/route.ts` y `src/app/api/images/[id]/route.ts`.
+
+---
+
+## 9. Casos borde
+
+- Foto sin display (recién subida con fallo, o pre-backfill): el visor cae a `fileUrl` (funciona, solo más pesado).
+- Imagen más chica que 2048px: `withoutEnlargement` evita agrandarla (la display puede igualar al original en px, pero re-encodeada a WebP → más liviana).
+- HEIC: convertir antes de generar la display (reutiliza la lógica del upload).
+- Colisión de nombre: la display deriva del `destName` ya único del original, así que no colisiona.
+
+---
+
+## 10. Componentes nuevos / tocados
+
+**Nuevo:** `scripts/generate-display-variants.ts`.
+**Tocados:**
+- `prisma/schema.prisma` (+ migración) — `Image.displayUrl`.
+- `src/lib/thumbnail.ts` — `generateDisplayFromBuffer`.
+- `src/lib/storage.ts` — helper de nombre `.display.webp` (o en thumbnail).
+- `src/app/api/upload/route.ts` — generar display + guardar `displayUrl`.
+- `src/app/api/albums/[id]/images/route.ts`, `src/app/api/images/[id]/route.ts` — incluir `displayUrl`.
+- `src/components/ImageGallery.tsx` — usar `displayUrl` en visor y preload.
+- `src/types/index.ts` — `displayUrl` en `AlbumImage`.
+
+El borrado de imagen (`api/images/[id]`) también debería borrar el archivo `.display.webp` además del original y la miniatura (evitar huérfanos).
+
+---
+
+## 11. Pruebas / verificación
+
+- **Unit:** helper de nombre de display (`<base>.display.webp`).
+- **E2E (dev):** subir una foto → existe `<base>.display.webp` en el árbol de thumbnails, `displayUrl` seteada, y el visor (HTML) referencia la URL display; el original intacto (sha256). Probar también con HEIC.
+- **Backfill:** correr en una copia con fotos planas migradas; verificar que genera displays para todas e idempotencia (segunda corrida no hace nada).
+- `pnpm test`, `tsc --noEmit`, `pnpm lint`, `pnpm build` en verde.
+
+---
+
+## 12. Despliegue
+
+1. Desplegar el código (build + recreate).
+2. `ALTER TABLE "images" ADD COLUMN IF NOT EXISTS "displayUrl" TEXT;` en la BD de producción.
+3. Correr el backfill una vez en un contenedor node (con los volúmenes montados), respaldo previo opcional (no destruye originales, solo agrega derivados).
+4. Verificar que el visor carga la versión display (peso ~400 KB) y el original sigue disponible.
+
+---
+
+## 13. Riesgos
+
+- Espacio en disco: ~250 MB extra para 583 displays (sobre 2.3 GB de originales) — trivial.
+- Tiempo de backfill: unos minutos (lee y re-encodea 583 imágenes).
+- Consistencia: el borrado de imagen debe incluir el `.display.webp` (cubierto en §10).

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "fix-db-dimensions": "tsx scripts/fix-db-dimensions.ts",
     "generate-icons": "node scripts/generate-icons.mjs",
     "test": "vitest run",
-    "migrate-folders": "tsx scripts/migrate-to-album-folders.ts"
+    "migrate-folders": "tsx scripts/migrate-to-album-folders.ts",
+    "generate-display": "tsx scripts/generate-display-variants.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.16.2",

--- a/prisma/migrations/20260614000000_add_image_display_url/migration.sql
+++ b/prisma/migrations/20260614000000_add_image_display_url/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."images" ADD COLUMN     "displayUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,6 +68,7 @@ model Image {
   originalName    String
   fileUrl         String
   thumbnailUrl    String?
+  displayUrl      String?
   fileSize        Int
   width           Int
   height          Int

--- a/scripts/generate-display-variants.ts
+++ b/scripts/generate-display-variants.ts
@@ -1,0 +1,50 @@
+import { PrismaClient } from '@prisma/client';
+import { readFile, access } from 'fs/promises';
+import path from 'path';
+import convert from 'heic-convert';
+import { generateDisplayFromBuffer } from '../src/lib/thumbnail';
+import { displayName, albumThumbDir, thumbUrl, UPLOADS_BASE } from '../src/lib/storage';
+
+const prisma = new PrismaClient();
+const exists = (p: string) => access(p).then(() => true).catch(() => false);
+
+function isHeicName(name: string): boolean {
+  const ext = path.extname(name).toLowerCase();
+  return ext === '.heic' || ext === '.heif';
+}
+
+async function main() {
+  const images = await prisma.image.findMany({ include: { album: true } });
+  let done = 0, skipped = 0, failed = 0;
+
+  for (const img of images) {
+    if (!img.album?.folderName) { skipped++; continue; }
+    const { year, folderName } = { year: img.album.year, folderName: img.album.folderName };
+    const origName = path.basename(img.fileUrl);
+    const dispName = displayName(origName);
+    const outPath = path.join(albumThumbDir(year, folderName), dispName);
+    const wantUrl = thumbUrl(year, folderName, dispName);
+
+    if (img.displayUrl === wantUrl && (await exists(outPath))) { skipped++; continue; }
+
+    const srcPath = path.join(UPLOADS_BASE, year.toString(), folderName, origName);
+    if (!(await exists(srcPath))) { console.warn(`sin original: ${img.fileUrl}`); failed++; continue; }
+
+    try {
+      let buf = await readFile(srcPath);
+      if (isHeicName(origName)) {
+        buf = Buffer.from(await convert({ buffer: buf, format: 'JPEG', quality: 0.92 }));
+      }
+      await generateDisplayFromBuffer(buf, outPath);
+      await prisma.image.update({ where: { id: img.id }, data: { displayUrl: wantUrl } });
+      done++;
+      if (done % 50 === 0) console.log(`${done} displays generadas...`);
+    } catch (e) {
+      console.error(`falló ${img.fileUrl}:`, (e as Error).message);
+      failed++;
+    }
+  }
+  console.log(`Backfill display completo. generadas=${done} saltadas=${skipped} fallidas=${failed}`);
+}
+
+main().then(() => prisma.$disconnect()).catch(async (e) => { console.error(e); await prisma.$disconnect(); process.exit(1); });

--- a/src/app/api/albums/[id]/images/route.ts
+++ b/src/app/api/albums/[id]/images/route.ts
@@ -44,6 +44,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           id: true,
           fileUrl: true,
           thumbnailUrl: true,
+          displayUrl: true,
           originalName: true,
           description: true,
           width: true,

--- a/src/app/api/images/[id]/route.ts
+++ b/src/app/api/images/[id]/route.ts
@@ -95,6 +95,11 @@ export async function DELETE(_request: NextRequest, { params }: RouteParams) {
         }
       } catch { console.warn('Miniatura no encontrada:', image.thumbnailUrl); }
     }
+    if (image.displayUrl && image.displayUrl.startsWith('/thumbnails/')) {
+      try {
+        await unlink(safeResolve(THUMBS_BASE, image.displayUrl.replace(/^\/thumbnails\//, '')));
+      } catch { console.warn('Display no encontrada:', image.displayUrl); }
+    }
 
     // Eliminar de la base de datos
     await prisma.image.delete({

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -251,6 +251,7 @@ export async function POST(request: NextRequest) {
         originalName: imageData.originalName,
         fileUrl: imageData.fileUrl,
         thumbnailUrl: imageData.thumbnailUrl,
+        displayUrl: imageData.displayUrl,
         fileSize: imageData.fileSize,
         width: imageData.width,
         height: imageData.height,

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { mkdir, writeFile, readdir } from 'fs/promises';
 import path from 'path';
 import { prisma } from '@/lib/prisma';
-import { generateThumbnailFromBuffer } from '@/lib/thumbnail';
+import { generateThumbnailFromBuffer, generateDisplayFromBuffer } from '@/lib/thumbnail';
 import sharp from 'sharp';
 import convert from 'heic-convert';
 import {
@@ -14,6 +14,7 @@ import {
   albumThumbDir,
   uploadUrl,
   thumbUrl,
+  displayName,
 } from '@/lib/storage';
 
 // Configuración para permitir archivos grandes (500MB máximo)
@@ -195,6 +196,15 @@ export async function POST(request: NextRequest) {
         thumbUrlValue = uploadUrl(year, folderName, destName); // fallback: usa el original
       }
 
+      // Versión "display" (2048px WebP) para el visor
+      let displayUrlValue: string | null = thumbUrl(year, folderName, displayName(destName));
+      try {
+        await generateDisplayFromBuffer(processBuffer, path.join(thumbsDir, displayName(destName)));
+      } catch {
+        console.warn(`No se pudo generar display para ${destName}`);
+        displayUrlValue = null;
+      }
+
       // Dimensiones reales POST-rotación (para el masonry)
       let realWidth = 800;
       let realHeight = 600;
@@ -225,6 +235,7 @@ export async function POST(request: NextRequest) {
           originalName: file.name,
           fileUrl: uploadUrl(year, folderName, destName),
           thumbnailUrl: thumbUrlValue,
+          displayUrl: displayUrlValue,
           fileSize: file.size,
           width: realWidth,
           height: realHeight,

--- a/src/components/ImageGallery.tsx
+++ b/src/components/ImageGallery.tsx
@@ -8,6 +8,7 @@ interface ImageData {
   id: string;
   fileUrl: string;
   thumbnailUrl?: string;
+  displayUrl?: string | null;
   originalName: string;
   description?: string | null;
   width?: number;
@@ -240,7 +241,7 @@ const ImageGallery = memo(function ImageGallery({ images, currentIndex, isOpen, 
     if (!isOpen) return;
     [idx - 1, idx + 1]
       .filter(i => i >= 0 && i < images.length)
-      .forEach(i => { const p = new window.Image(); p.src = images[i].fileUrl; });
+      .forEach(i => { const p = new window.Image(); p.src = images[i].displayUrl || images[i].fileUrl; });
   }, [idx, images, isOpen]);
 
   // Focus management
@@ -355,7 +356,7 @@ const ImageGallery = memo(function ImageGallery({ images, currentIndex, isOpen, 
                 >
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
-                    src={img.fileUrl}
+                    src={img.displayUrl || img.fileUrl}
                     alt={img.originalName}
                     className={`max-w-[90vw] max-h-[65vh] object-contain block pointer-events-none transition-opacity duration-200 ${loading ? 'opacity-0' : 'opacity-100'}`}
                     onLoad={() => setLoading(false)}

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -51,6 +51,18 @@ describe('uniqueSlug', () => {
   });
 });
 
+import { displayName } from './storage';
+
+describe('displayName', () => {
+  test('reemplaza la extensión por .display.webp', () => {
+    expect(displayName('IMG_1234.jpg')).toBe('IMG_1234.display.webp');
+    expect(displayName('foto.HEIC')).toBe('foto.display.webp');
+  });
+  test('sin extensión, agrega .display.webp', () => {
+    expect(displayName('archivo')).toBe('archivo.display.webp');
+  });
+});
+
 import { safeResolve, uploadUrl, thumbUrl } from './storage';
 import path from 'path';
 

--- a/src/lib/storage.test.ts
+++ b/src/lib/storage.test.ts
@@ -54,12 +54,12 @@ describe('uniqueSlug', () => {
 import { displayName } from './storage';
 
 describe('displayName', () => {
-  test('reemplaza la extensión por .display.webp', () => {
-    expect(displayName('IMG_1234.jpg')).toBe('IMG_1234.display.webp');
-    expect(displayName('foto.HEIC')).toBe('foto.display.webp');
+  test('devuelve la ruta display/<base>.webp', () => {
+    expect(displayName('IMG_1234.jpg')).toBe('display/IMG_1234.webp');
+    expect(displayName('foto.HEIC')).toBe('display/foto.webp');
   });
-  test('sin extensión, agrega .display.webp', () => {
-    expect(displayName('archivo')).toBe('archivo.display.webp');
+  test('sin extensión', () => {
+    expect(displayName('archivo')).toBe('display/archivo.webp');
   });
 });
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -43,10 +43,16 @@ export function uniqueSlug(desired: string, taken: Set<string>): string {
   return `${desired}-${i}`;
 }
 
-/** Nombre del archivo "display" derivado del nombre destino: IMG_1.jpg → IMG_1.display.webp */
+/**
+ * Ruta relativa (dentro de la carpeta de thumbnails del álbum) de la variante
+ * "display" derivada del nombre destino: IMG_1.jpg → display/IMG_1.webp
+ * La subcarpeta `display/` separa el namespace de las miniaturas para que un
+ * original llamado p.ej. "x.display.jpg" no pueda colisionar con la display de "x.jpg".
+ */
 export function displayName(name: string): string {
   const ext = path.extname(name);
-  return name.slice(0, name.length - ext.length) + '.display.webp';
+  const base = name.slice(0, name.length - ext.length);
+  return `display/${base}.webp`;
 }
 
 /** Resuelve `relPath` contra `baseDir` garantizando que no escape (path traversal). Lanza si escapa. */

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -43,6 +43,12 @@ export function uniqueSlug(desired: string, taken: Set<string>): string {
   return `${desired}-${i}`;
 }
 
+/** Nombre del archivo "display" derivado del nombre destino: IMG_1.jpg → IMG_1.display.webp */
+export function displayName(name: string): string {
+  const ext = path.extname(name);
+  return name.slice(0, name.length - ext.length) + '.display.webp';
+}
+
 /** Resuelve `relPath` contra `baseDir` garantizando que no escape (path traversal). Lanza si escapa. */
 export function safeResolve(baseDir: string, relPath: string): string {
   const base = path.resolve(baseDir);

--- a/src/lib/thumbnail.ts
+++ b/src/lib/thumbnail.ts
@@ -73,6 +73,30 @@ export async function generateThumbnailFromBuffer(
     .toFile(outputPath);
 }
 
+const DISPLAY_CONFIG = {
+  maxSize: 2048,
+  quality: 82,
+};
+
+/** Genera la versión "display" (máx 2048px WebP) para el visor, desde un buffer. */
+export async function generateDisplayFromBuffer(
+  buffer: Buffer,
+  outputPath: string
+): Promise<void> {
+  const outputDir = path.dirname(outputPath);
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  await sharp(buffer)
+    .rotate()
+    .resize(DISPLAY_CONFIG.maxSize, DISPLAY_CONFIG.maxSize, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .webp({ quality: DISPLAY_CONFIG.quality })
+    .toFile(outputPath);
+}
+
 /**
  * Genera un thumbnail para un archivo subido
  * @param filename Nombre del archivo (ej: "1234_abcd.jpg")

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,7 @@ export interface AlbumImage {
   id: string;
   fileUrl: string;
   thumbnailUrl: string;
+  displayUrl?: string | null;
   originalName: string;
   description: string | null;
   width: number;


### PR DESCRIPTION
## Resumen

El visor cargaba el **original completo** (varios MB) por foto → lento en móvil. Ahora usa una versión **"display" WebP de máx 2048px** (~400KB), conservando el original intacto.

- Tercer derivado, hermano de la miniatura, en `public/thumbnails/<año>/<álbum>/display/<base>.webp` (subcarpeta `display/` para no colisionar con las miniaturas). Servido por la ruta `/thumbnails/[...path]` existente — **sin volumen ni ruta nuevos, sin tocar el compose**.
- Campo `Image.displayUrl`. El visor usa `displayUrl || fileUrl` (fallback al original).
- Se genera en el **upload** (desde el mismo buffer, incluye conversión HEIC), y se rellena para las fotos existentes con `pnpm generate-display` (idempotente).
- Borrar una imagen elimina también su `.display.webp` (sin huérfanos).
- Preload de adyacentes usa la display → deslizar es instantáneo.

## Validación
- E2E (dev): subir JPEG **y HEIC** → display generada en `display/`, `displayUrl` en BD + API, sirve 200, original **sha256 idéntico**. Borrar imagen → display eliminada (0 huérfanos).
- `pnpm test` (17/17), `tsc` (0), `lint` (0 errores), `pnpm build` (exit 0).
- Revisión de código: sin hallazgos ALTA; colisión MEDIA eliminada con la subcarpeta.

## Test Plan / Despliegue
- [ ] Desplegar (build + recreate).
- [ ] `ALTER TABLE "images" ADD COLUMN IF NOT EXISTS "displayUrl" TEXT;` en prod.
- [ ] Backfill: `pnpm generate-display` (en contenedor node con volúmenes montados) — genera las ~583 displays.
- [ ] Abrir una foto en el visor y confirmar que carga rápido (~400KB).