### PR TITLE
build: deploy autónomo (sin CasaOS, build desde fuente)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Despliegue de album-fotos como stack docker-compose autónomo.
+# Actualiza el código, reconstruye la imagen y recrea los contenedores.
+# Uso (en el servidor):  ./deploy.sh
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "==> git pull"
+git pull
+
+echo "==> docker compose up -d --build"
+docker compose up -d --build
+
+echo "==> estado:"
+docker compose ps
+
+echo "Deploy completo."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,9 +21,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    labels:
-      # Label de CasaOS para el icono
-      icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/postgres.png
     networks:
       - album-network
 
@@ -31,10 +28,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    image: album-fotos-app:latest
     container_name: album-fotos-app
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      # host:contenedor — el acceso (LAN y Tailscale serve) usa 3300
+      - "3300:3000"
     environment:
       NODE_ENV: production
       DATABASE_URL: postgresql://postgres:password@postgres:5432/album_fotos?schema=public
@@ -56,56 +55,6 @@ services:
       - ./data:/app/data
     networks:
       - album-network
-    labels:
-      # Labels para CasaOS
-      icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextjs.png
-      net.unraid.docker.managed: composeman
-      net.unraid.docker.icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextjs.png
-    x-casaos:
-      # Metadata de CasaOS para mejor integración
-      architectures:
-        - amd64
-        - arm64
-      main: app
-      description:
-        en_us: "Album de Fotos - Sistema de gestión de álbumes fotográficos organizados por años"
-      tagline:
-        en_us: "Galería de fotos moderna con Next.js"
-      developer: "Custom"
-      author: "Custom"
-      icon: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextjs.png
-      thumbnail: https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons/png/nextjs.png
-      title:
-        en_us: "Album de Fotos"
-      category: "Media"
-      port_map: "3000"
-      tips:
-        before_install:
-          en_us: |
-            Aplicación de álbum de fotos con Next.js y PostgreSQL.
-            Accede en: http://tu-servidor:3000
-      envs:
-        - container: NODE_ENV
-          description:
-            en_us: "Node environment (production/development)"
-        - container: DATABASE_URL
-          description:
-            en_us: "PostgreSQL connection string"
-      ports:
-        - container: "3000"
-          description:
-            en_us: "WebUI HTTP Port"
-          protocol: "tcp"
-      volumes:
-        - container: /app/public/uploads
-          description:
-            en_us: "Imágenes originales subidas"
-        - container: /app/public/thumbnails
-          description:
-            en_us: "Miniaturas generadas"
-        - container: /app/data
-          description:
-            en_us: "Datos de la aplicación"
 
 networks:
   album-network:


### PR DESCRIPTION
Deja album-fotos como stack docker-compose independiente, igual que las otras apps del server: `build:` desde el Dockerfile (deploy con `docker compose up -d --build`), puerto 3300, volúmenes existentes preservados, sin labels de CasaOS. Agrega `deploy.sh` (un comando). Prepara para retirar CasaOS sin romper nada.