### PR TITLE
fix: subir fotos en Android (MIME vacío)

### DIFF
--- a/src/app/admin/upload/page.tsx
+++ b/src/app/admin/upload/page.tsx
@@ -7,6 +7,13 @@ import { useToast } from "@/components/Toast";
 import { FadeUp } from "@/components/MotionWrap";
 import type { AlbumSummary } from "@/types";
 
+const IMAGE_EXT = /\.(jpe?g|png|gif|webp|avif|heic|heif|tiff?|bmp)$/i;
+// En Android las fotos de la galería suelen llegar con `type` vacío (sobre todo
+// HEIC), así que aceptamos también por extensión, no solo por MIME.
+function isImageFile(f: File): boolean {
+  return f.type.startsWith("image/") || IMAGE_EXT.test(f.name);
+}
+
 function UploadContent() {
   const { t } = useTheme();
   const { addToast } = useToast();
@@ -42,14 +49,14 @@ function UploadContent() {
     e.stopPropagation();
     setDragActive(false);
     if (e.dataTransfer.files?.[0]) {
-      const imageFiles = Array.from(e.dataTransfer.files).filter((f) => f.type.startsWith("image/"));
+      const imageFiles = Array.from(e.dataTransfer.files).filter(isImageFile);
       setSelectedFiles((prev) => [...prev, ...imageFiles]);
     }
   };
 
   const handleFileInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files) {
-      const imageFiles = Array.from(e.target.files).filter((f) => f.type.startsWith("image/"));
+      const imageFiles = Array.from(e.target.files).filter(isImageFile);
       setSelectedFiles((prev) => [...prev, ...imageFiles]);
     }
   };
@@ -137,7 +144,7 @@ function UploadContent() {
               >
                 Seleccionar Archivos
               </label>
-              <p className={`text-xs ${t.textMuted} mt-4`}>JPG, PNG, GIF, WebP (max 10MB)</p>
+              <p className={`text-xs ${t.textMuted} mt-4`}>JPG, PNG, HEIC, WebP, GIF (máx 100MB)</p>
             </div>
           </div>
 

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -41,6 +41,10 @@ const ALLOWED_MIME_TYPES = new Set([
   'image/tiff',
 ]);
 
+// Extensiones de imagen aceptadas. Android suele subir fotos con `type` vacío,
+// así que validamos también por extensión cuando el MIME no es confiable.
+const ALLOWED_EXT = /\.(jpe?g|png|gif|webp|avif|heic|heif|tiff?)$/i;
+
 // HEIC/HEIF (formato por defecto del iPhone) no lo decodifica sharp.
 // Se detecta por mime o extensión para convertirlo antes de generar derivados.
 function isHeic(file: File): boolean {
@@ -149,8 +153,10 @@ export async function POST(request: NextRequest) {
     const skippedFiles: { name: string; reason: string }[] = [];
 
     for (const file of files) {
-      // Validar tipo: debe ser una imagen de un formato soportado
-      if (!file.type.startsWith('image/') || !ALLOWED_MIME_TYPES.has(file.type)) {
+      // Validar tipo: por MIME (si viene) o por extensión (Android suele no mandar MIME)
+      const mimeOk = file.type.startsWith('image/') && ALLOWED_MIME_TYPES.has(file.type);
+      const extOk = ALLOWED_EXT.test(file.name);
+      if (!mimeOk && !extOk) {
         skippedFiles.push({ name: file.name, reason: `Tipo no soportado (${file.type || 'desconocido'})` });
         continue;
       }

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,5 +1,10 @@
 import { redirect } from "next/navigation";
 
-export default function UploadPage() {
-  redirect("/admin/upload");
+export default async function UploadPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ album?: string }>;
+}) {
+  const { album } = await searchParams;
+  redirect(album ? `/admin/upload?album=${encodeURIComponent(album)}` : "/admin/upload");
 }


### PR DESCRIPTION
En Android las fotos de la galería llegan con `file.type` vacío (sobre todo HEIC), y el filtro por MIME las descartaba todas → no se mostraban para subir. Se acepta también por extensión en el selector (cliente) y en la validación del servidor. Además `/upload` ahora conserva el `?album=` al redirigir, y el texto de ayuda corrige formatos/límite (HEIC, 100MB).