### PR TITLE
fix: Subir va directo a /admin/upload (sin redirect roto en PWA)

### DIFF
--- a/src/app/album/[year]/page.tsx
+++ b/src/app/album/[year]/page.tsx
@@ -324,7 +324,7 @@ function AlbumPageContent({ params }: { params: Promise<{ year: string }> }) {
                   {album.description && <p className={`text-sm ${t.textMuted} mb-2`}>{album.description}</p>}
                   <div className="flex items-center justify-between">
                     <span className={`text-sm ${t.textMuted}`}>{album.imageCount} fotos</span>
-                    <Link href={`/upload?album=${album.id}`} onClick={e => e.stopPropagation()} className={`text-sm ${t.accent}`}>Subir</Link>
+                    <Link href={`/admin/upload?album=${album.id}`} onClick={e => e.stopPropagation()} className={`text-sm ${t.accent}`}>Subir</Link>
                   </div>
                 </div>
               </StaggerItem>
@@ -443,7 +443,7 @@ function AlbumPageContent({ params }: { params: Promise<{ year: string }> }) {
             </div>
             <h3 className={`text-xl font-semibold ${t.text} mb-2`}>Álbum vacío</h3>
             <p className={`${t.textMuted} mb-6 max-w-sm mx-auto`}>Sube fotos para llenar este álbum.</p>
-            <Link href={`/upload?album=${selectedAlbum}`}>
+            <Link href={`/admin/upload?album=${selectedAlbum}`}>
               <button className="px-6 py-3 rounded-xl text-white font-medium btn-glass-accent">Subir Fotos</button>
             </Link>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,7 +80,7 @@ export default function Home() {
             </div>
             <h3 className={`font-display text-2xl font-medium ${t.text} mb-2`}>Sin fotos todavía</h3>
             <p className={`${t.textMuted} mb-6 max-w-sm mx-auto`}>Sube tus primeras fotos para comenzar a crear tu galería.</p>
-            <Link href="/upload">
+            <Link href="/admin/upload">
               <button className="btn-glass-accent px-6 py-3 rounded-xl text-white font-medium">Subir Fotos</button>
             </Link>
           </div>


### PR DESCRIPTION
Los links de 'Subir' iban a /upload (redirect del servidor a /admin/upload). En la PWA el service worker intercepta la navegación y el redirect cae al fallback de la home → rebotaba a la vista de álbumes. Ahora apuntan directo a /admin/upload, conservando el ?album=.