### PR TITLE
fix: sw.js siempre revalidado (evita SW viejo pegado)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -48,6 +48,16 @@ const nextConfig: NextConfig = {
   async headers() {
     return [
       {
+        // El service worker debe revalidarse siempre, para que las
+        // actualizaciones (nuevas versiones del SW) lleguen a los dispositivos
+        // sin quedar pegados en una versión vieja cacheada.
+        source: '/sw.js',
+        headers: [
+          { key: 'Cache-Control', value: 'no-cache, no-store, must-revalidate' },
+          { key: 'Service-Worker-Allowed', value: '/' },
+        ],
+      },
+      {
         source: '/uploads/:path*',
         headers: [
           {


### PR DESCRIPTION
Agrega Cache-Control no-cache al /sw.js para que las actualizaciones del service worker lleguen a los dispositivos y no queden mostrando datos cacheados viejos.