### PR TITLE
fix: zoom solo en el visor + modal de portada con scroll

### DIFF
--- a/src/app/admin/albums/[id]/page.tsx
+++ b/src/app/admin/albums/[id]/page.tsx
@@ -106,7 +106,7 @@ function FocalPointModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
-      <div className="bg-neutral-900 rounded-2xl shadow-2xl w-full max-w-3xl overflow-hidden">
+      <div className="bg-neutral-900 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90dvh] overflow-y-auto">
         <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
           <h2 className="text-white font-semibold text-base">{title}</h2>
           <button onClick={onCancel} className="p-1.5 rounded-lg text-white/60 hover:text-white hover:bg-white/10 transition-colors">

--- a/src/app/admin/years/[year]/page.tsx
+++ b/src/app/admin/years/[year]/page.tsx
@@ -58,7 +58,7 @@ function FocalPointModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm p-4">
-      <div className="bg-neutral-900 rounded-2xl shadow-2xl w-full max-w-3xl overflow-hidden">
+      <div className="bg-neutral-900 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90dvh] overflow-y-auto">
         <div className="flex items-center justify-between px-5 py-4 border-b border-white/10">
           <h2 className="text-white font-semibold text-base">Editar punto focal de la portada del año</h2>
           <button onClick={onCancel} className="p-1.5 rounded-lg text-white/60 hover:text-white hover:bg-white/10 transition-colors">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,6 +45,10 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
   themeColor: '#2f6b6b',
+  // El zoom con dos dedos queda deshabilitado en la UI; el visor de fotos
+  // tiene su propio zoom (pinch/doble-tap/rueda), así que ahí sí se puede.
+  maximumScale: 1,
+  userScalable: false,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Desactiva el pinch-zoom nativo en la UI (el visor de fotos mantiene su zoom propio JS) y agrega max-h+overflow al modal de punto focal de portada para que 'Guardar' sea alcanzable en móvil.